### PR TITLE
feat: BLE device background service added

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,18 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
+    
+    <!-- Bluetooth Permissions -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    
+    <!-- Foreground Service Permissions -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
     <application
         android:label="flutter_setup"
         android:name="${applicationName}"
@@ -37,6 +49,18 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        
+        <!-- Background Service for BLE -->
+        <service
+            android:name="id.flutter.flutter_background_service.BackgroundService"
+            android:foregroundServiceType="connectedDevice"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true"/>
+        <service
+            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"
+            android:stopWithTask="false" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+Future<void> initializeBackgroundService() async {
+  try {
+    final service = FlutterBackgroundService();
+
+    const AndroidNotificationChannel channel = AndroidNotificationChannel(
+      'ble_foreground',
+      'BLE Background Service',
+      description: 'This channel is used for BLE background service.',
+      importance: Importance.low,
+    );
+
+    final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+        FlutterLocalNotificationsPlugin();
+
+    if (Platform.isAndroid) {
+      await flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.createNotificationChannel(channel);
+      print('Notification channel created');
+    }
+
+    await service.configure(
+      androidConfiguration: AndroidConfiguration(
+        onStart: onStart,
+        autoStart: false,
+        isForegroundMode: true,
+        notificationChannelId: 'ble_foreground',
+        initialNotificationTitle: 'BLE Service',
+        initialNotificationContent: 'Running',
+        foregroundServiceNotificationId: 888,
+      ),
+      iosConfiguration: IosConfiguration(
+        autoStart: false,
+        onForeground: onStart,
+        onBackground: onIosBackground,
+      ),
+    );
+    print('Background service configured successfully');
+  } catch (e) {
+    print('Error in initializeBackgroundService: $e');
+    rethrow;
+  }
+}
+
+@pragma('vm:entry-point')
+void onStart(ServiceInstance service) async {
+  DartPluginRegistrant.ensureInitialized();
+
+  if (service is AndroidServiceInstance) {
+    service.on('setAsForeground').listen((event) {
+      service.setAsForegroundService();
+    });
+
+    service.on('setAsBackground').listen((event) {
+      service.setAsBackgroundService();
+    });
+
+    service.on('updateContent').listen((event) {
+      if (event != null && event['message'] != null) {
+        service.setForegroundNotificationInfo(
+          title: "BLE Manager",
+          content: "Last: ${event['message']}",
+        );
+      }
+    });
+  }
+
+  service.on('stopService').listen((event) {
+    service.stopSelf();
+  });
+
+  Timer.periodic(const Duration(seconds: 5), (timer) async {
+    if (service is AndroidServiceInstance) {
+      if (await service.isForegroundService()) {
+        service.setForegroundNotificationInfo(
+          title: "BLE Manager",
+          content: "Maintaining connection...",
+        );
+      }
+    }
+  });
+}
+
+/// iOS
+@pragma('vm:entry-point')
+bool onIosBackground(ServiceInstance service) {
+  WidgetsFlutterBinding.ensureInitialized();
+  return true;
+}
+

--- a/lib/data/services/ble_manager.dart
+++ b/lib/data/services/ble_manager.dart
@@ -1,0 +1,349 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_setup/data/services/sos_service.dart';
+
+class BLEManager {
+  static final BLEManager _instance = BLEManager._internal();
+  factory BLEManager() => _instance;
+  BLEManager._internal();
+
+  BluetoothDevice? connectedDevice;
+  BluetoothCharacteristic? notifyCharacteristic;
+  StreamSubscription<List<int>>? characteristicSubscription;
+  StreamSubscription<BluetoothConnectionState>? connectionStateSubscription;
+  StreamSubscription<List<ScanResult>>? _scanSubscription;
+  Timer? _reconnectTimer;
+
+  bool _isAutoConnecting = false;
+  bool _shouldAutoConnect = true;
+
+  final ValueNotifier<String> statusNotifier = ValueNotifier('Initializing...');
+  final ValueNotifier<bool> isConnectedNotifier = ValueNotifier(false);
+
+
+  Future<bool> initialize() async {
+    try {
+      statusNotifier.value = 'Requesting permissions...';
+      final hasPermissions = await _requestPermissions();
+      if (!hasPermissions) {
+        statusNotifier.value = 'Permissions not granted';
+        return false;
+      }
+
+      statusNotifier.value = 'Permissions granted';
+      
+      await _startBackgroundService();
+      
+      return true;
+    } catch (e) {
+      print('Error initializing BLE Manager: $e');
+      statusNotifier.value = 'Initialization failed: $e';
+      return false;
+    }
+  }
+
+  Future<void> _startBackgroundService() async {
+    try {
+      final service = FlutterBackgroundService();
+      if (!await service.isRunning()) {
+        await service.startService();
+      }
+      service.invoke('setAsForeground');
+      service.invoke('updateContent', {"message": "BLE Service Ready - Monitoring for device"});
+      print('Background service started with notification');
+    } catch (e) {
+      print('Error starting background service: $e');
+    }
+  }
+
+  /////////BLE permissions
+  Future<bool> _requestPermissions() async {
+    try {
+      if (Platform.isAndroid) {
+        await Permission.notification.request();
+        final bluetoothScanStatus = await Permission.bluetoothScan.request();
+        final bluetoothConnectStatus = await Permission.bluetoothConnect.request();
+        final locationStatus = await Permission.location.request();
+        
+        print('BLE Permissions Status:');
+        print('  Notification: ${await Permission.notification.status}');
+        print('  Bluetooth Scan: $bluetoothScanStatus');
+        print('  Bluetooth Connect: $bluetoothConnectStatus');
+        print('  Location: $locationStatus');
+        
+        return bluetoothScanStatus.isGranted &&
+            bluetoothConnectStatus.isGranted &&
+            locationStatus.isGranted;
+      } else if (Platform.isIOS) {
+        final bluetoothStatus = await Permission.bluetooth.request();
+        return bluetoothStatus.isGranted;
+      }
+      return false;
+    } catch (e) {
+      print('Error requesting BLE permissions: $e');
+      return false;
+    }
+  }
+
+  /// Start auto-connecting to saved device or scan for device
+  Future<void> startAutoConnect() async {
+    if (_isAutoConnecting || !_shouldAutoConnect) return;
+    
+    _isAutoConnecting = true;
+    statusNotifier.value = 'Starting auto-connect...';
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final savedDeviceId = prefs.getString('ble_device_id');
+
+      if (savedDeviceId != null && savedDeviceId.isNotEmpty) {
+        statusNotifier.value = 'Connecting to saved device...';
+        await _connectToDeviceById(savedDeviceId);
+      } else {
+        statusNotifier.value = 'Scanning for device...';
+        await _scanAndConnect();
+      }
+    } catch (e) {
+      print('Error in auto-connect: $e');
+      statusNotifier.value = 'Auto-connect failed: $e';
+      _scheduleReconnect();
+    } finally {
+      _isAutoConnecting = false;
+    }
+  }
+
+  /// Connect to device by ID - SATOSHI use this for specific bluetooth device
+  Future<void> _connectToDeviceById(String deviceId) async {
+    try {
+      final devices = await FlutterBluePlus.connectedDevices;
+      for (var device in devices) {
+        if (device.remoteId.toString() == deviceId) {
+          await _connect(device);
+          return;
+        }
+      }
+
+      await _scanAndConnect();
+    } catch (e) {
+      print('Error connecting to device by ID: $e');
+      await _scanAndConnect();
+    }
+  }
+
+  Future<void> _scanAndConnect() async {
+    try {
+      _scanSubscription?.cancel();
+      
+      statusNotifier.value = 'Scanning for BLE device...';
+      await FlutterBluePlus.startScan(timeout: const Duration(seconds: 10));
+
+      _scanSubscription = FlutterBluePlus.scanResults.listen((results) async {
+      final service = FlutterBackgroundService();
+      if (await service.isRunning()) {
+        service.invoke('updateContent', {"message": "Scanning for BLE device..."});
+      }
+
+      if (results.isNotEmpty && connectedDevice == null && _shouldAutoConnect) {
+          //////Connect to first device found (you may want to filter by name/UUID)
+          final device = results.first.device;
+          await FlutterBluePlus.stopScan();
+          await _connect(device);
+          
+          //////Save device ID for future connections
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setString('ble_device_id', device.remoteId.toString());
+        }
+      });
+
+      /////timeout
+      await Future.delayed(const Duration(seconds: 10));
+      await FlutterBluePlus.stopScan();
+      _scanSubscription?.cancel();
+
+      if (connectedDevice == null) {
+        statusNotifier.value = 'Device not found. Retrying...';
+        final service = FlutterBackgroundService();
+        if (await service.isRunning()) {
+          service.invoke('updateContent', {"message": "BLE Service Ready - Monitoring for device"});
+        }
+        _scheduleReconnect();
+      }
+    } catch (e) {
+      print('Error scanning: $e');
+      statusNotifier.value = 'Scan failed: $e';
+      _scheduleReconnect();
+    }
+  }
+
+  //////Connect to a specific device
+  Future<void> _connect(BluetoothDevice device) async {
+    if (connectedDevice != null) return;
+
+    try {
+      statusNotifier.value = 'Connecting...';
+      
+      connectionStateSubscription?.cancel();
+      connectionStateSubscription = device.connectionState.listen((state) {
+        if (state == BluetoothConnectionState.disconnected) {
+          _handleDisconnection();
+        } else if (state == BluetoothConnectionState.connected) {
+          isConnectedNotifier.value = true;
+          statusNotifier.value = 'Connected';
+        }
+      });
+
+      await device.connect(timeout: const Duration(seconds: 15));
+
+      connectedDevice = device;
+      isConnectedNotifier.value = true;
+      statusNotifier.value = 'Connected';
+
+      final service = FlutterBackgroundService();
+      if (!await service.isRunning()) {
+        await service.startService();
+      }
+      service.invoke('setAsForeground');
+      service.invoke('updateContent', {"message": "BLE Device Connected - Monitoring"});
+
+      await _discoverServices(device);
+    } catch (e) {
+      print('Connection error: $e');
+      statusNotifier.value = 'Connection failed: $e';
+      isConnectedNotifier.value = false;
+      _scheduleReconnect();
+    }
+  }
+
+  Future<void> _discoverServices(BluetoothDevice device) async {
+    try {
+      List<BluetoothService> services = await device.discoverServices();
+      
+      for (var service in services) {
+        String serviceUuid = service.uuid.toString().toUpperCase();
+        if (serviceUuid.contains('ABF0') || serviceUuid.contains('0000ABF0')) {
+          for (var characteristic in service.characteristics) {
+            String charUuid = characteristic.uuid.toString().toUpperCase();
+            if (charUuid.contains('ABF2') || charUuid.contains('0000ABF2')) {
+              await _subscribe(characteristic);
+              return;
+            }
+          }
+        }
+      }
+
+      /////Fallback
+      for (var service in services) {
+        for (var characteristic in service.characteristics) {
+          if (characteristic.properties.notify || characteristic.properties.indicate) {
+            await _subscribe(characteristic);
+            return;
+          }
+        }
+      }
+
+      statusNotifier.value = 'No data channel found';
+    } catch (e) {
+      print('Service discovery error: $e');
+      statusNotifier.value = 'Service discovery failed: $e';
+    }
+  }
+
+  ///bluetooth device messages recieve
+  Future<void> _subscribe(BluetoothCharacteristic characteristic) async {
+    try {
+      notifyCharacteristic = characteristic;
+      await characteristic.setNotifyValue(true);
+
+      characteristicSubscription?.cancel();
+      characteristicSubscription = characteristic.lastValueStream.listen(
+        (value) {
+          if (value.isNotEmpty) {
+            try {
+              String message = utf8.decode(value, allowMalformed: true).trim();
+              print('BLE Received: $message');
+
+              FlutterBackgroundService().invoke(
+                "updateContent",
+                {"message": "Received: $message"},
+              );
+
+              ////Trigger SOS when message is received from BLE device
+              // Satoshi, you can modify this to check for specific message content (e.g., "SOS", "EMERGENCY", etc.)
+              print('Triggering SOS from BLE device');
+              SOSService().triggerSOS();
+            } catch (e) {
+              print('Error decoding message: $e');
+            }
+          }
+        },
+        onError: (error) {
+          print('Characteristic stream error: $error');
+          statusNotifier.value = 'Data stream error';
+        },
+      );
+
+      statusNotifier.value = 'Listening for SOS signals';
+    } catch (e) {
+      print('Subscribe error: $e');
+      statusNotifier.value = 'Subscribe failed: $e';
+    }
+  }
+
+  /// Handle disconnection
+  void _handleDisconnection() {
+    isConnectedNotifier.value = false;
+    statusNotifier.value = 'Device disconnected';
+
+    characteristicSubscription?.cancel();
+    connectionStateSubscription?.cancel();
+    connectedDevice = null;
+    notifyCharacteristic = null;
+
+    final service = FlutterBackgroundService();
+    service.invoke('updateContent', {"message": "BLE Service Ready - Monitoring for device"});
+
+    if (_shouldAutoConnect) {
+      _scheduleReconnect();
+    }
+  }
+
+  void _scheduleReconnect() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(const Duration(seconds: 5), () {
+      if (_shouldAutoConnect && connectedDevice == null) {
+        startAutoConnect();
+      }
+    });
+  }
+
+  Future<void> stop() async {
+    _shouldAutoConnect = false;
+    _reconnectTimer?.cancel();
+    _scanSubscription?.cancel();
+    
+    if (connectedDevice != null) {
+      await characteristicSubscription?.cancel();
+      await connectionStateSubscription?.cancel();
+      
+      try {
+        await connectedDevice!.disconnect();
+      } catch (e) {
+        print('Disconnect error: $e');
+      }
+      
+      connectedDevice = null;
+      notifyCharacteristic = null;
+      isConnectedNotifier.value = false;
+      
+      final service = FlutterBackgroundService();
+      service.invoke('updateContent', {"message": "BLE Service Ready - Monitoring for device"});
+    }
+  }
+}
+

--- a/lib/data/services/ble_service.dart
+++ b/lib/data/services/ble_service.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+///Message data model for BLE messages - subject to change(satoshi)
+class BLEMessage {
+  final String message;
+  final DateTime timestamp;
+  BLEMessage({required this.message, required this.timestamp});
+}
+
+enum BLEConnectionStatus {
+  disconnected,
+  connecting,
+  connected,
+}
+
+class BLEService {
+  static final BLEService _instance = BLEService._internal();
+  factory BLEService() => _instance;
+  BLEService._internal();
+
+  BluetoothDevice? connectedDevice;
+  BluetoothCharacteristic? notifyCharacteristic;
+  StreamSubscription<List<int>>? characteristicSubscription;
+  StreamSubscription<BluetoothConnectionState>? connectionStateSubscription;
+
+  final ValueNotifier<List<BLEMessage>> messagesNotifier = ValueNotifier([]);
+  final ValueNotifier<String> statusNotifier = ValueNotifier('Ready to scan');
+  final ValueNotifier<BLEConnectionStatus> connectionStatusNotifier =
+      ValueNotifier(BLEConnectionStatus.disconnected);
+
+  Future<bool> _requestPermissions() async {
+    try {
+      if (Platform.isAndroid) {
+        await Permission.notification.request();
+        final bluetoothScanStatus = await Permission.bluetoothScan.request();
+        final bluetoothConnectStatus = await Permission.bluetoothConnect.request();
+        final locationStatus = await Permission.location.request();
+        
+        print('BLE Permissions Status:');
+        print('  Bluetooth Scan: $bluetoothScanStatus');
+        print('  Bluetooth Connect: $bluetoothConnectStatus');
+        print('  Location: $locationStatus');
+        
+        return bluetoothScanStatus.isGranted &&
+            bluetoothConnectStatus.isGranted &&
+            locationStatus.isGranted;
+      } else if (Platform.isIOS) {
+        final bluetoothStatus = await Permission.bluetooth.request();
+        return bluetoothStatus.isGranted;
+      }
+      return false;
+    } catch (e) {
+      print('Error requesting BLE permissions: $e');
+      return false;
+    }
+  }
+
+  /////cnnect to a BLE device
+  Future<void> connect(BluetoothDevice device) async {
+    final hasPermissions = await _requestPermissions();
+    if (!hasPermissions) {
+      statusNotifier.value = 'Permissions not granted';
+      return;
+    }
+
+    statusNotifier.value = 'Connecting...';
+    connectionStatusNotifier.value = BLEConnectionStatus.connecting;
+
+    try {
+      connectionStateSubscription?.cancel();
+      connectionStateSubscription = device.connectionState.listen((state) {
+        if (state == BluetoothConnectionState.disconnected) {
+          _handleDisconnection();
+        }
+      });
+
+      await device.connect(
+        timeout: const Duration(seconds: 15),
+      );
+
+      connectedDevice = device;
+      connectionStatusNotifier.value = BLEConnectionStatus.connected;
+      statusNotifier.value = 'Connected';
+
+      final service = FlutterBackgroundService();
+      if (!await service.isRunning()) {
+        await service.startService();
+      }
+      service.invoke('setAsForeground');
+      service.invoke('updateContent', {"message": "Connected to device"});
+      await _discoverServices(device);
+    } catch (e) {
+      statusNotifier.value = 'Connection failed: ${e.toString()}';
+      connectionStatusNotifier.value = BLEConnectionStatus.disconnected;
+      connectedDevice = null;
+    }
+  }
+
+  Future<void> _discoverServices(BluetoothDevice device) async {
+    try {
+      List<BluetoothService> services = await device.discoverServices();
+      for (var service in services) {
+        String serviceUuid = service.uuid.toString().toUpperCase();
+        if (serviceUuid.contains('ABF0') || serviceUuid.contains('0000ABF0')) {
+          for (var characteristic in service.characteristics) {
+            String charUuid = characteristic.uuid.toString().toUpperCase();
+            if (charUuid.contains('ABF2') || charUuid.contains('0000ABF2')) {
+              await _subscribe(characteristic);
+              return;
+            }
+          }
+        }
+      }
+
+      ////Fallback
+      for (var service in services) {
+        for (var characteristic in service.characteristics) {
+          if (characteristic.properties.notify ||
+              characteristic.properties.indicate) {
+            await _subscribe(characteristic);
+            return;
+          }
+        }
+      }
+
+      statusNotifier.value = 'No data channel found';
+    } catch (e) {
+      statusNotifier.value = 'Service discovery failed: ${e.toString()}';
+    }
+  }
+
+  
+  Future<void> _subscribe(BluetoothCharacteristic characteristic) async {
+    try {
+      notifyCharacteristic = characteristic;
+      await characteristic.setNotifyValue(true);
+
+      characteristicSubscription?.cancel();
+      characteristicSubscription = characteristic.lastValueStream.listen(
+        (value) {
+          if (value.isNotEmpty) {
+            try {
+              String message = utf8.decode(value, allowMalformed: true).trim();
+              print('BLE Received: $message');
+
+              final currentMsgs = List<BLEMessage>.from(messagesNotifier.value);
+              currentMsgs.insert(
+                0,
+                BLEMessage(message: message, timestamp: DateTime.now()),
+              );
+
+              if (currentMsgs.length > 100) {
+                currentMsgs.removeRange(100, currentMsgs.length);
+              }
+
+              messagesNotifier.value = currentMsgs;
+              FlutterBackgroundService().invoke(
+                "updateContent",
+                {"message": message},
+              );
+            } catch (e) {
+              print('Error decoding message: $e');
+            }
+          }
+        },
+        onError: (error) {
+          print('Characteristic stream error: $error');
+          statusNotifier.value = 'Data stream error';
+        },
+      );
+
+      statusNotifier.value = 'Listening for data';
+    } catch (e) {
+      statusNotifier.value = 'Subscribe failed: ${e.toString()}';
+    }
+  }
+
+  void _handleDisconnection() {
+    connectionStatusNotifier.value = BLEConnectionStatus.disconnected;
+    statusNotifier.value = 'Device disconnected';
+
+    characteristicSubscription?.cancel();
+    connectionStateSubscription?.cancel();
+
+    connectedDevice = null;
+    notifyCharacteristic = null;
+
+    final service = FlutterBackgroundService();
+    service.invoke("stopService");
+  }
+
+  Future<void> disconnect() async {
+    if (connectedDevice != null) {
+      await characteristicSubscription?.cancel();
+      await connectionStateSubscription?.cancel();
+
+      try {
+        await connectedDevice!.disconnect();
+      } catch (e) {
+        print('Disconnect error: $e');
+      }
+
+      connectedDevice = null;
+      notifyCharacteristic = null;
+      connectionStatusNotifier.value = BLEConnectionStatus.disconnected;
+      statusNotifier.value = 'Disconnected';
+
+      final service = FlutterBackgroundService();
+      service.invoke("stopService");
+    }
+  }
+
+  //////Clear messages
+  void clearMessages() {
+    messagesNotifier.value = [];
+  }
+}
+

--- a/lib/data/services/sos_service.dart
+++ b/lib/data/services/sos_service.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_setup/bloc/home_bloc.dart';
+
+class SOSService {
+  static final SOSService _instance = SOSService._internal();
+  factory SOSService() => _instance;
+  SOSService._internal();
+
+  HomeBloc? _homeBloc;
+  void setHomeBloc(HomeBloc homeBloc) {
+    _homeBloc = homeBloc;
+  }
+
+  void triggerSOS() {
+    if (_homeBloc != null) {
+      print('SOS Service: Triggering emergency SOS');
+      _homeBloc!.add(HelpButtonClickedEvent());
+    } else {
+      print('SOS Service: HomeBloc not set, cannot trigger SOS');
+    }
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_setup/bloc/home_bloc.dart';
+import 'package:flutter_setup/data/services/background_service.dart';
+import 'package:flutter_setup/data/services/ble_manager.dart';
 import 'package:flutter_setup/router/router_config.dart';
 import 'package:flutter_setup/theme/app_theme.dart';
 import 'package:go_router/go_router.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  
+  try {
+    await initializeBackgroundService();
+    print('Background service initialized successfully');
+  } catch (e) {
+    print('Error initializing background service: $e');
+  }
+
+  try {
+    final bleManager = BLEManager();
+    final initialized = await bleManager.initialize();
+    if (initialized) {
+      print('BLE Manager initialized, starting auto-connect...');
+      bleManager.startAutoConnect();
+    } else {
+      print('BLE Manager initialization failed - permissions not granted');
+    }
+  } catch (e) {
+    print('Error initializing BLE Manager: $e');
+  }
+  
   runApp(const MyApp());
 }
 

--- a/lib/pages/home_screen.dart
+++ b/lib/pages/home_screen.dart
@@ -3,21 +3,39 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_setup/bloc/home_bloc.dart';
 import 'package:flutter_setup/components/navigation_drawer.dart';
+import 'package:flutter_setup/data/services/sos_service.dart';
 import 'package:flutter_setup/theme/app_theme.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class HomeScreen extends StatelessWidget {
-  HomeScreen({super.key});
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
 
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
   final _formKey = GlobalKey<FormState>();
   final _areaController = TextEditingController();
   final _landmarkController = TextEditingController();
   final _descriptionController = TextEditingController();
+  late HomeBloc homeBloc;
+
+  @override
+  void initState() {
+    super.initState();
+    homeBloc = HomeBloc();
+    SOSService().setHomeBloc(homeBloc);
+  }
+
+  @override
+  void dispose() {
+    homeBloc.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    HomeBloc homeBloc = HomeBloc();
-
     return BlocConsumer(
       bloc: homeBloc,
       listener: (context, state) {},
@@ -332,7 +350,7 @@ class HomeScreen extends StatelessWidget {
                     },
                   );
 
-                  context.read<HomeBloc>().add(HelpButtonClickedEvent());
+                  homeBloc.add(HelpButtonClickedEvent());
 
                   await Future.delayed(const Duration(seconds: 2));
 
@@ -680,7 +698,7 @@ class HomeScreen extends StatelessWidget {
                   ),
                 );
               } else if (_formKey.currentState!.validate()) {
-                context.read<HomeBloc>().add(HelpFormSubmittedEvent(
+                homeBloc.add(HelpFormSubmittedEvent(
                     area: _areaController.text,
                     landmark: _landmarkController.text,
                     description: _descriptionController.text));

--- a/lib/utils/ble_permissions.dart
+++ b/lib/utils/ble_permissions.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'package:permission_handler/permission_handler.dart';
+
+Future<bool> requestBLEPermissions() async {
+  try {
+    if (Platform.isAndroid) {
+      // Request notification permission
+      await Permission.notification.request();
+      
+      // Request Bluetooth permissions
+      final bluetoothScanStatus = await Permission.bluetoothScan.request();
+      final bluetoothConnectStatus = await Permission.bluetoothConnect.request();
+      
+      // Request location permission
+      final locationStatus = await Permission.location.request();
+      
+      print('BLE Permissions Status:');
+      print('  Notification: ${await Permission.notification.status}');
+      print('  Bluetooth Scan: $bluetoothScanStatus');
+      print('  Bluetooth Connect: $bluetoothConnectStatus');
+      print('  Location: $locationStatus');
+      
+      final isGranted = bluetoothScanStatus.isGranted &&
+          bluetoothConnectStatus.isGranted &&
+          locationStatus.isGranted;
+      
+      return isGranted;
+    } else if (Platform.isIOS) {
+      final bluetoothStatus = await Permission.bluetooth.request();
+      print('BLE Permission Status (iOS): $bluetoothStatus');
+      return bluetoothStatus.isGranted;
+    }
+    return false;
+  } catch (e) {
+    print('Error requesting BLE permissions: $e');
+    return false;
+  }
+}
+
+Future<bool> checkBLEPermissions() async {
+  try {
+    if (Platform.isAndroid) {
+      final bluetoothScan = await Permission.bluetoothScan.status;
+      final bluetoothConnect = await Permission.bluetoothConnect.status;
+      final location = await Permission.location.status;
+      
+      return bluetoothScan.isGranted &&
+          bluetoothConnect.isGranted &&
+          location.isGranted;
+    } else if (Platform.isIOS) {
+      final bluetooth = await Permission.bluetooth.status;
+      return bluetooth.isGranted;
+    }
+    return false;
+  } catch (e) {
+    print('Error checking BLE permissions: $e');
+    return false;
+  }
+}
+

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,8 @@ import Foundation
 
 import firebase_auth
 import firebase_core
+import flutter_blue_plus_darwin
+import flutter_local_notifications
 import location
 import shared_preferences_foundation
 import url_launcher_macos
@@ -14,6 +16,8 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FlutterBluePlusPlugin.register(with: registry.registrar(forPlugin: "FlutterBluePlusPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   LocationPlugin.register(with: registry.registrar(forPlugin: "LocationPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.49"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -25,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
+  bluez:
+    dependency: transitive
+    description:
+      name: bluez
+      sha256: "61a7204381925896a374301498f2f5399e59827c6498ae1e924aaa598751b545"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -73,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   dio:
     dependency: "direct main"
     description:
@@ -174,6 +198,38 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_background_service:
+    dependency: "direct main"
+    description:
+      name: flutter_background_service
+      sha256: "70a1c185b1fa1a44f8f14ecd6c86f6e50366e3562f00b2fa5a54df39b3324d3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
+  flutter_background_service_android:
+    dependency: transitive
+    description:
+      name: flutter_background_service_android
+      sha256: ca0793d4cd19f1e194a130918401a3d0b1076c81236f7273458ae96987944a87
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  flutter_background_service_ios:
+    dependency: transitive
+    description:
+      name: flutter_background_service_ios
+      sha256: "6037ffd45c4d019dab0975c7feb1d31012dd697e25edc05505a4a9b0c7dc9fba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
+  flutter_background_service_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_background_service_platform_interface
+      sha256: ca74aa95789a8304f4d3f57f07ba404faa86bed6e415f83e8edea6ad8b904a41
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.2"
   flutter_bloc:
     dependency: "direct main"
     description:
@@ -182,6 +238,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
+  flutter_blue_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_blue_plus
+      sha256: "69a8c87c11fc792e8cf0f997d275484fbdb5143ac9f0ac4d424429700cb4e0ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.36.8"
+  flutter_blue_plus_android:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_android
+      sha256: "6f7fe7e69659c30af164a53730707edc16aa4d959e4c208f547b893d940f853d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.4"
+  flutter_blue_plus_darwin:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_darwin
+      sha256: "682982862c1d964f4d54a3fb5fccc9e59a066422b93b7e22079aeecd9c0d38f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
+  flutter_blue_plus_linux:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_linux
+      sha256: "56b0c45edd0a2eec8f85bd97a26ac3cd09447e10d0094fed55587bf0592e3347"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
+  flutter_blue_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_platform_interface
+      sha256: "84fbd180c50a40c92482f273a92069960805ce324e3673ad29c41d2faaa7c5c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  flutter_blue_plus_web:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_web
+      sha256: a1aceee753d171d24c0e0cdadb37895b5e9124862721f25f60bb758e20b72c99
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -198,6 +302,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.2.4"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -408,6 +536,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -432,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -541,6 +685,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   typed_data:
     dependency: transitive
     description:
@@ -645,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,9 @@ dependencies:
   location: ^7.0.1
   url_launcher: ^6.3.1
   call_log: ^6.0.1
+  flutter_blue_plus: ^1.32.11
+  flutter_background_service: ^5.0.0
+  flutter_local_notifications: ^17.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
_// Auto-connects to first discovered device_
`BLEManager().startAutoConnect()`

_// Connects to specific device_
`BLEManager().connect(device)`

_// Service discovery, looks for ABF0/ABF2 or fallback_
`_discoverServices(device)`

_// Subscribes to characteristic notifications_
`_subscribe(characteristic)`



1. **`ble_manager.dart`**
   - Singleton BLE manager
   - Handles scanning, connecting, data reception
   - Auto-reconnect logic
   - Background service integration

2. **`background_service.dart`**
   - Foreground service setup
   - Notification channel configuration
   - Service lifecycle management

3. **`sos_service.dart`**
   - Bridge between BLE manager and HomeBloc
   - Triggers SOS when BLE data received

4. **`main.dart`**
   - Initializes BLE manager on app start
   - Requests permissions
   - Starts auto-connect process